### PR TITLE
Add Package.json to the root of your directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "redcap_rsvc",
+  "version": "14.5.5",
+  "description": "Version-specific feature tests written in Gherkin for the Regulatory and Software Validation Committee.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/4bbakers/redcap_rsvc.git"
+  },
+  "author": "Theresa Baker",
+  "license": "MIT"
+}


### PR DESCRIPTION
Initially, I need your feature test files to have this file in place so that I can pull the feature tests directly from your fork of GitHub instead of having to always sync across to my fork first. 

This will greatly speed up the time it takes to run the feature test updates for you because I won't have to maintain a separate branch I have to sync on my fork.

In the long run, I'm hoping we can create a workflow where you can push the feature tests to this redcap_rsvc repository and it will trigger an **automatic run** of the CI / CD pipeline.  What that means is that the tests would run in the CI/CD environment for you automatically and you wouldn't need to do anything other than push updates to your repo.

In other words, I'd like to take me out of the equation and empower you to run the feature tests yourself because right now I feel like I'm standing in your way.

It will take a bit of work, but this is the first step to get there.