### PR TITLE
Update Project_1.xml

### DIFF
--- a/Feature Tests/B/Data Access Groups_10/B.2.10.0300. - Multiple DAGs.feature
+++ b/Feature Tests/B/Data Access Groups_10/B.2.10.0300. - Multiple DAGs.feature
@@ -78,7 +78,7 @@ Feature: B.2.10.0300. User Interface: The system shall allow a user to be added 
         And I select "3" on the dropdown field labeled "Choose an existing Record ID"
         Then I should see "Record ID 3"
 
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 
@@ -91,7 +91,7 @@ Feature: B.2.10.0300. User Interface: The system shall allow a user to be added 
         And I select "4" on the dropdown field labeled "Choose an existing Record ID"
         Then I should see "Record ID 4"
 
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 

--- a/Feature Tests/B/Data Access Groups_10/B.2.10.0400. - User and Record Restrictions.feature
+++ b/Feature Tests/B/Data Access Groups_10/B.2.10.0400. - User and Record Restrictions.feature
@@ -75,7 +75,7 @@ Feature: B.2.10.0400. User Interface: The system shall provide the ability to re
         And I select "3" on the dropdown field labeled "Choose an existing Record ID"
         Then I should see "Record ID 3"
 
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 
@@ -88,7 +88,7 @@ Feature: B.2.10.0400. User Interface: The system shall provide the ability to re
         And I select "4" on the dropdown field labeled "Choose an existing Record ID"
         Then I should see "Record ID 4"
 
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 

--- a/Feature Tests/B/Data Access Groups_10/B.2.10.0500. - REDUNDANT.Assign Records to DAG.feature
+++ b/Feature Tests/B/Data Access Groups_10/B.2.10.0500. - REDUNDANT.Assign Records to DAG.feature
@@ -18,7 +18,7 @@ Feature: User Interface: The system shall provide the ability to assign records 
 
         #FUNCTIONAL REQUIREMENT
         ##ACTION: Assign Record DAG
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 

--- a/Feature Tests/B/Data Access Groups_10/B.2.10.0600. - Unique DAGs.feature
+++ b/Feature Tests/B/Data Access Groups_10/B.2.10.0600. - Unique DAGs.feature
@@ -18,7 +18,7 @@ Feature: User Interface: The system shall provide the DAG unique group names in 
         When I select record ID "3" from arm name "Arm 1: Arm 1" on the Add / Edit record page
         Then I should see "Record Home Page"
 
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 
@@ -33,7 +33,7 @@ Feature: User Interface: The system shall provide the DAG unique group names in 
         When I select record ID "4" from arm name "Arm 1: Arm 1" on the Add / Edit record page
         Then I should see "Record Home Page"
 
-        Given I click on the span element labeled "Choose action for record"
+        Given I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         Then I should see a dialog containing the following text: "Assign record to a Data Access Group?"
 

--- a/Feature Tests/B/Data Import_16/B.3.16.0900. - Import Restrictions.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0900. - Import Restrictions.feature
@@ -32,7 +32,7 @@ Feature: User Interface: The system shall not allow data to be changed on locked
     When I click on the link labeled "Record Status Dashboard"
     And I click on the link labeled exactly "1"
     #And I select the dropdown option labeled "Lock entire record" for the dropdown field labeled "Choose action for record"
-    When I click on the span element labeled "Choose action for record"
+    When I click on the button labeled "Choose action for record"
     And I click on the link labeled "Lock entire record"
     And I click on the button labeled "Lock entire record" on the dialog box
     Then I should see a dialog containing the following text: 'Record "1" is now LOCKED'

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0900. - Rename Record.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.0900. - Rename Record.feature
@@ -47,7 +47,7 @@ Feature: Renaming a Record: The system shall allow users to rename a record.
         When I click on the link labeled "Record Status Dashboard"
         And I click on the link labeled exactly "1"
         ##ACTION Rename record
-        When I click on the span element labeled "Choose action for record"
+        When I click on the button labeled "Choose action for record"
         And I click on the link labeled "Rename record"
         Then I should see a dialog containing the following text: 'Rename record "1"'
 

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1200. - Delete Record.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1200. - Delete Record.feature
@@ -49,7 +49,7 @@ Feature: B.3.14.1200. The system shall allow users to delete a record from the R
 
         ##FUNCTIONAL_REQUIREMENT
         ###ACTION Delete record
-        When I click on the span element labeled "Choose action for record"
+        When I click on the button labeled "Choose action for record"
         And I click on the link labeled "Delete record (all forms/events)"
         Then I should see a dialog containing the following text: 'DELETE RECORD "1"?'
 

--- a/Feature Tests/C/Reporting_22/C.5.22.0100. - Report Access.feature
+++ b/Feature Tests/C/Reporting_22/C.5.22.0100. - Report Access.feature
@@ -20,7 +20,7 @@ Feature: User Interface: The system shall support the ability to assign the User
         #SETUP: Assign record 1 to DAG1
         When I click on the link labeled "Record Status Dashboard"
         And I click on the link labeled exactly "1"
-        And I click on the span element labeled "Choose action for record"
+        And I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         When I select "TestGroup1" on the dropdown field labeled "Assign record" on the dialog box
         And I click on the button labeled "Assign to Data Access Group" in the dialog box
@@ -29,7 +29,7 @@ Feature: User Interface: The system shall support the ability to assign the User
         #SETUP: Assign record 2 to DAG2
         When I click on the link labeled "Record Status Dashboard"
         And I click on the link labeled exactly "2"
-        And I click on the span element labeled "Choose action for record"
+        And I click on the button labeled "Choose action for record"
         And I click on the link labeled "Assign to Data Access Group"
         When I select "TestGroup2" on the dropdown field labeled "Assign record" on the dialog box
         And I click on the button labeled "Assign to Data Access Group" in the dialog box

--- a/Files/cdisc_files/Project_1.xml
+++ b/Files/cdisc_files/Project_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="project_1.xml" AsOfDateTime="2024-10-07T17:20:56" CreationDateTime="2024-10-07T17:20:56" SourceSystem="REDCap" SourceSystemVersion="14.5.5">
+<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="project_1.xml" AsOfDateTime="2024-11-22T13:55:43" CreationDateTime="2024-11-22T13:55:43" SourceSystem="REDCap" SourceSystemVersion="14.5.5">
 <Study OID="Project.Project1xml">
 <GlobalVariables>
 	<StudyName>project_1.xml</StudyName>
@@ -59,14 +59,14 @@
 &lt;p&gt;Have a nice day!&lt;/p&gt;" stop_action_acknowledgement="" stop_action_delete_response="0" question_by_section="0" display_page_number="0" question_auto_numbering="1" survey_enabled="1" save_and_return="0" save_and_return_code_bypass="0" logo="" hide_title="0" view_results="0" min_responses_view_results="10" check_diversity_view_results="0" end_survey_redirect_url="" survey_expiration="" promis_skip_question="0" survey_auth_enabled_single="0" edit_completed_response="0" hide_back_button="0" show_required_field_text="1" confirmation_email_subject="" confirmation_email_content="" confirmation_email_from="" confirmation_email_from_display="" confirmation_email_attach_pdf="0" confirmation_email_attachment="" text_to_speech="0" text_to_speech_language="en" end_survey_redirect_next_survey="0" end_survey_redirect_next_survey_logic="" theme="" text_size="1" font_family="16" theme_text_buttons="" theme_bg_page="" theme_text_title="" theme_bg_title="" theme_text_sectionheader="" theme_bg_sectionheader="" theme_text_question="" theme_bg_question="" enhanced_choices="0" repeat_survey_enabled="0" repeat_survey_btn_text="" repeat_survey_btn_location="BEFORE_SUBMIT" response_limit="" response_limit_include_partials="1" response_limit_custom_text="&lt;p&gt;Thank you for your interest; however, the survey is closed because the maximum number of responses has been reached.&lt;/p&gt;" survey_time_limit_days="" survey_time_limit_hours="" survey_time_limit_minutes="" email_participant_field="" end_of_survey_pdf_download="0" pdf_save_to_field="" pdf_save_to_event_id="" pdf_save_translated="0" pdf_auto_archive="1" pdf_econsent_version="" pdf_econsent_type="" pdf_econsent_firstname_field="" pdf_econsent_firstname_event_id="" pdf_econsent_lastname_field="" pdf_econsent_lastname_event_id="" pdf_econsent_dob_field="" pdf_econsent_dob_event_id="" pdf_econsent_allow_edit="1" pdf_econsent_signature_field1="" pdf_econsent_signature_field2="" pdf_econsent_signature_field3="" pdf_econsent_signature_field4="" pdf_econsent_signature_field5="" survey_width_percent="" survey_show_font_resize="1" survey_btn_text_prev_page="" survey_btn_text_next_page="" survey_btn_text_submit="" survey_btn_hide_submit="0" survey_btn_hide_submit_logic=""/>
 		<redcap:Surveys form_name="consent" title="Consent" instructions="&lt;p&gt;&lt;strong&gt;Please complete the survey below.&lt;/strong&gt;&lt;/p&gt;
 &lt;p&gt;Thank you!&lt;/p&gt;" offline_instructions="" acknowledgement="&lt;p&gt;&lt;strong&gt;Thank you for taking the survey.&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;Have a nice day!&lt;/p&gt;" stop_action_acknowledgement="" stop_action_delete_response="0" question_by_section="0" display_page_number="0" question_auto_numbering="1" survey_enabled="1" save_and_return="0" save_and_return_code_bypass="0" logo="" hide_title="0" view_results="0" min_responses_view_results="10" check_diversity_view_results="0" end_survey_redirect_url="" survey_expiration="" promis_skip_question="0" survey_auth_enabled_single="0" edit_completed_response="0" hide_back_button="0" show_required_field_text="1" confirmation_email_subject="test consent" confirmation_email_content="&lt;p&gt;test consent&lt;/p&gt;" confirmation_email_from="teresa.bosler@vumc.org" confirmation_email_from_display="" confirmation_email_attach_pdf="1" confirmation_email_attachment="" text_to_speech="0" text_to_speech_language="en" end_survey_redirect_next_survey="0" end_survey_redirect_next_survey_logic="" theme="" text_size="1" font_family="16" theme_text_buttons="" theme_bg_page="" theme_text_title="" theme_bg_title="" theme_text_sectionheader="" theme_bg_sectionheader="" theme_text_question="" theme_bg_question="" enhanced_choices="0" repeat_survey_enabled="0" repeat_survey_btn_text="" repeat_survey_btn_location="BEFORE_SUBMIT" response_limit="" response_limit_include_partials="1" response_limit_custom_text="&lt;p&gt;Thank you for your interest; however, the survey is closed because the maximum number of responses has been reached.&lt;/p&gt;" survey_time_limit_days="" survey_time_limit_hours="" survey_time_limit_minutes="" email_participant_field="" end_of_survey_pdf_download="0" pdf_save_to_field="" pdf_save_to_event_id="" pdf_save_translated="0" pdf_auto_archive="2" pdf_econsent_version="test" pdf_econsent_type="test" pdf_econsent_firstname_field="name" pdf_econsent_firstname_event_id="3137" pdf_econsent_lastname_field="email" pdf_econsent_lastname_event_id="3137" pdf_econsent_dob_field="dob" pdf_econsent_dob_event_id="3137" pdf_econsent_allow_edit="1" pdf_econsent_signature_field1="" pdf_econsent_signature_field2="" pdf_econsent_signature_field3="" pdf_econsent_signature_field4="" pdf_econsent_signature_field5="" survey_width_percent="" survey_show_font_resize="1" survey_btn_text_prev_page="" survey_btn_text_next_page="" survey_btn_text_submit="" survey_btn_hide_submit="0" survey_btn_hide_submit_logic=""/>
+&lt;p&gt;Have a nice day!&lt;/p&gt;" stop_action_acknowledgement="" stop_action_delete_response="0" question_by_section="1" display_page_number="0" question_auto_numbering="1" survey_enabled="1" save_and_return="0" save_and_return_code_bypass="0" logo="" hide_title="0" view_results="0" min_responses_view_results="10" check_diversity_view_results="0" end_survey_redirect_url="" survey_expiration="" promis_skip_question="0" survey_auth_enabled_single="0" edit_completed_response="0" hide_back_button="0" show_required_field_text="1" confirmation_email_subject="" confirmation_email_content="" confirmation_email_from="" confirmation_email_from_display="" confirmation_email_attach_pdf="0" confirmation_email_attachment="" text_to_speech="0" text_to_speech_language="en" end_survey_redirect_next_survey="0" end_survey_redirect_next_survey_logic="" theme="" text_size="1" font_family="16" theme_text_buttons="" theme_bg_page="" theme_text_title="" theme_bg_title="" theme_text_sectionheader="" theme_bg_sectionheader="" theme_text_question="" theme_bg_question="" enhanced_choices="0" repeat_survey_enabled="0" repeat_survey_btn_text="" repeat_survey_btn_location="BEFORE_SUBMIT" response_limit="" response_limit_include_partials="1" response_limit_custom_text="&lt;p&gt;Thank you for your interest; however, the survey is closed because the maximum number of responses has been reached.&lt;/p&gt;" survey_time_limit_days="" survey_time_limit_hours="" survey_time_limit_minutes="" email_participant_field="" end_of_survey_pdf_download="0" pdf_save_to_field="" pdf_save_to_event_id="" pdf_save_translated="0" pdf_auto_archive="0" pdf_econsent_version="" pdf_econsent_type="" pdf_econsent_firstname_field="" pdf_econsent_firstname_event_id="" pdf_econsent_lastname_field="" pdf_econsent_lastname_event_id="" pdf_econsent_dob_field="" pdf_econsent_dob_event_id="" pdf_econsent_allow_edit="0" pdf_econsent_signature_field1="" pdf_econsent_signature_field2="" pdf_econsent_signature_field3="" pdf_econsent_signature_field4="" pdf_econsent_signature_field5="" survey_width_percent="" survey_show_font_resize="1" survey_btn_text_prev_page="" survey_btn_text_next_page="" survey_btn_text_submit="" survey_btn_hide_submit="0" survey_btn_hide_submit_logic=""/>
 	</redcap:SurveysGroup>
 	<redcap:EconsentGroup>
-		<redcap:Econsent survey_id="consent" version="test" active="1" type_label="test" custom_econsent_label="" notes="" firstname_field="name" firstname_event_id="event_1_arm_1" lastname_field="email" lastname_event_id="3137" dob_field="dob" dob_event_id="3137" allow_edit="1" signature_field1="" signature_field2="" signature_field3="" signature_field4="" signature_field5="" consent_form_location_field="" ID="da4b9237bacccdf19c0760cab7aec4a8359010b0"/>
+		<redcap:Econsent survey_id="consent" version="" active="1" type_label="" custom_econsent_label="" notes="" firstname_field="" firstname_event_id="event_1_arm_1" lastname_field="" lastname_event_id="40" dob_field="" dob_event_id="40" allow_edit="0" signature_field1="" signature_field2="" signature_field3="" signature_field4="" signature_field5="" consent_form_location_field="" ID="356a192b7913b04c54574d18c28d46e6395428ab"/>
 	</redcap:EconsentGroup>
 	<redcap:PdfSnapshotsGroup>
 		<redcap:PdfSnapshots active="1" name="" custom_filename_prefix="pid[project-id]_form[instrument-label]_id[record-name]" consent_id="" trigger_surveycomplete_survey_id="survey" trigger_surveycomplete_event_id="" trigger_logic="" selected_forms_events=":survey" pdf_save_to_file_repository="1" pdf_save_to_field="" pdf_save_to_event_id="" pdf_save_translated="0" pdf_compact="1"/>
-		<redcap:PdfSnapshots active="1" name="" custom_filename_prefix="[event_1_arm_1][name]_[event_1_arm_1][email]_[event_1_arm_1][dob]_pid[project-id]_form[instrument-label]_id[record-name]" consent_id="da4b9237bacccdf19c0760cab7aec4a8359010b0" trigger_surveycomplete_survey_id="consent" trigger_surveycomplete_event_id="" trigger_logic="" selected_forms_events=":consent" pdf_save_to_file_repository="1" pdf_save_to_field="" pdf_save_to_event_id="" pdf_save_translated="1" pdf_compact="1"/>
+		<redcap:PdfSnapshots active="1" name="" custom_filename_prefix="pid[project-id]_form[instrument-label]_id[record-name]" consent_id="356a192b7913b04c54574d18c28d46e6395428ab" trigger_surveycomplete_survey_id="consent" trigger_surveycomplete_event_id="" trigger_logic="" selected_forms_events=":consent" pdf_save_to_file_repository="1" pdf_save_to_field="" pdf_save_to_event_id="" pdf_save_translated="1" pdf_compact="1"/>
 	</redcap:PdfSnapshotsGroup>
 	<redcap:UserRolesGroup>
 		<redcap:UserRoles role_name="1_FullRights" unique_role_name="U-641DLAC49L" lock_record="0" lock_record_multiform="0" lock_record_customize="1" data_export_tool="" data_export_instruments="[text_validation,1][data_types,1][survey,1][consent,1]" data_import_tool="1" data_comparison_tool="1" data_logging="1" email_logging="1" file_repository="1" double_data="0" user_rights="1" data_access_groups="1" graphical="1" reports="1" design="1" alerts="1" calendar="1" data_entry="[text_validation,1][data_types,1][survey,3][consent,3]" api_export="0" api_import="0" api_modules="0" mobile_app="0" mobile_app_download_data="0" record_create="1" record_rename="1" record_delete="1" dts="0" participants="1" data_quality_design="1" data_quality_execute="1" data_quality_resolution="1" random_setup="1" random_dashboard="1" random_perform="1" realtime_webservice_mapping="0" realtime_webservice_adjudicate="0" external_module_config="" mycap_participants="1"/>
@@ -76,10 +76,10 @@
 		<redcap:UserRoles role_name="TestRole" unique_role_name="U-523YNH3DEY" lock_record="0" lock_record_multiform="0" lock_record_customize="1" data_export_tool="" data_export_instruments="[text_validation,1][data_types,1][survey,1][consent,1]" data_import_tool="1" data_comparison_tool="1" data_logging="1" email_logging="1" file_repository="1" double_data="0" user_rights="1" data_access_groups="1" graphical="1" reports="1" design="1" alerts="1" calendar="1" data_entry="[text_validation,1][data_types,1]" api_export="0" api_import="0" api_modules="0" mobile_app="0" mobile_app_download_data="0" record_create="1" record_rename="1" record_delete="1" dts="0" participants="1" data_quality_design="1" data_quality_execute="1" data_quality_resolution="1" random_setup="1" random_dashboard="1" random_perform="1" realtime_webservice_mapping="0" realtime_webservice_adjudicate="0" external_module_config="" mycap_participants="1"/>
 	</redcap:UserRolesGroup>
 	<redcap:ReportsGroup>
-		<redcap:Reports title="Test Report" unique_report_name="R-153R3EA4W3" report_order="1" user_access="ALL" user_edit_access="ALL" description="" combine_checkbox_values="0" output_dags="0" output_survey_fields="0" output_missing_data_codes="0" remove_line_breaks_in_values="1" orderby_field1="record_id" orderby_sort1="ASC" orderby_field2="" orderby_sort2="" orderby_field3="" orderby_sort3="" advanced_logic="" filter_type="RECORD" dynamic_filter1="" dynamic_filter2="" dynamic_filter3="" hash="EEPLFPWJ3YEFPR8F" short_url="" is_public="0" report_display_include_repeating_fields="1" report_display_header="BOTH" report_display_data="BOTH" limiter_logic="" redcap_reports_fields="record_id,text_validation_complete,ptname,text2,textbox,notesbox,calculated_field,multiple_dropdown_auto,multiple_dropdown_manual,radio_button_manual,checkbox,signature,file_upload,required,identifier,identifier_2,edit_field,data_types_complete" redcap_reports_filter_dags="" redcap_reports_filter_events="" ID="08ec2efcf0142e45c607570add5be471abd4504c"/>
+		<redcap:Reports title="Test Report" unique_report_name="R-153R3EA4W3" report_order="1" user_access="ALL" user_edit_access="ALL" description="" combine_checkbox_values="0" output_dags="0" output_survey_fields="0" output_missing_data_codes="0" remove_line_breaks_in_values="1" orderby_field1="record_id" orderby_sort1="ASC" orderby_field2="" orderby_sort2="" orderby_field3="" orderby_sort3="" advanced_logic="" filter_type="RECORD" dynamic_filter1="" dynamic_filter2="" dynamic_filter3="" hash="" short_url="" is_public="0" report_display_include_repeating_fields="1" report_display_header="BOTH" report_display_data="BOTH" limiter_logic="" redcap_reports_fields="record_id,text_validation_complete,ptname,text2,textbox,notesbox,calculated_field,multiple_dropdown_auto,multiple_dropdown_manual,radio_button_manual,checkbox,signature,file_upload,required,identifier,identifier_2,edit_field,data_types_complete" redcap_reports_filter_dags="" redcap_reports_filter_events="" ID="356a192b7913b04c54574d18c28d46e6395428ab"/>
 	</redcap:ReportsGroup>
 </GlobalVariables>
-<MetaDataVersion OID="Metadata.Project1xml_2024-10-07_1720" Name="project_1.xml" redcap:RecordIdField="record_id">
+<MetaDataVersion OID="Metadata.Project1xml_2024-11-22_1355" Name="project_1.xml" redcap:RecordIdField="record_id">
 	<Protocol>
 		<StudyEventRef StudyEventOID="Event.event_1_arm_1" OrderNumber="1" Mandatory="No"/>
 		<StudyEventRef StudyEventOID="Event.event_2_arm_1" OrderNumber="2" Mandatory="No"/>
@@ -514,15 +514,15 @@
 		<CodeListItem CodedValue="100"><Decode><TranslatedText>Choice100</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="101"><Decode><TranslatedText>Choice101</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="checkbox___1.choices" Name="checkbox___1" DataType="boolean" redcap:Variable="checkbox" redcap:CheckboxChoices="1, Checkbox1 | 2, Checkbox2 | 3, Checkbox3">
+	<CodeList OID="checkbox___1.choices" Name="checkbox___1" DataType="boolean" redcap:Variable="checkbox" redcap:CheckboxChoices="1, Checkbox1|2, Checkbox2|3, Checkbox3">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="checkbox___2.choices" Name="checkbox___2" DataType="boolean" redcap:Variable="checkbox" redcap:CheckboxChoices="1, Checkbox1 | 2, Checkbox2 | 3, Checkbox3">
+	<CodeList OID="checkbox___2.choices" Name="checkbox___2" DataType="boolean" redcap:Variable="checkbox" redcap:CheckboxChoices="1, Checkbox1|2, Checkbox2|3, Checkbox3">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="checkbox___3.choices" Name="checkbox___3" DataType="boolean" redcap:Variable="checkbox" redcap:CheckboxChoices="1, Checkbox1 | 2, Checkbox2 | 3, Checkbox3">
+	<CodeList OID="checkbox___3.choices" Name="checkbox___3" DataType="boolean" redcap:Variable="checkbox" redcap:CheckboxChoices="1, Checkbox1|2, Checkbox2|3, Checkbox3">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
@@ -543,7 +543,7 @@
 	</CodeList>
 </MetaDataVersion>
 </Study>
-<ClinicalData StudyOID="Project.Project1xml" MetaDataVersionOID="Metadata.Project1xml_2024-10-07_1720">
+<ClinicalData StudyOID="Project.Project1xml" MetaDataVersionOID="Metadata.Project1xml_2024-11-22_1355">
 	<SubjectData SubjectKey="1" redcap:RecordIdField="record_id">
 		<StudyEventData StudyEventOID="Event.event_1_arm_1" StudyEventRepeatKey="1" redcap:UniqueEventName="event_1_arm_1">
 			<FormData FormOID="Form.text_validation" FormRepeatKey="1">
@@ -556,8 +556,7 @@
 				</ItemGroupData>
 			</FormData>
 			<FormData FormOID="Form.consent" FormRepeatKey="1">
-				<ItemGroupData ItemGroupOID="consent.consent_timestamp" ItemGroupRepeatKey="1">
-					<ItemData ItemOID="consent_timestamp" Value="2023-04-14 19:22:00"/>
+				<ItemGroupData ItemGroupOID="" ItemGroupRepeatKey="1">
 					<ItemData ItemOID="name_consent" Value="Name "/>
 					<ItemData ItemOID="email_consent" Value="email@test.edu"/>
 					<ItemData ItemOID="dob" Value="2023-04-14"/>
@@ -730,6 +729,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>
@@ -762,6 +762,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>
@@ -785,7 +786,6 @@
 			<FormData FormOID="Form.text_validation" FormRepeatKey="1">
 				<ItemGroupData ItemGroupOID="text_validation.record_id" ItemGroupRepeatKey="1">
 					<ItemData ItemOID="record_id" Value="3"/>
-					<ItemData ItemOID="redcap_data_access_group" Value="testgroup1"/>
 				</ItemGroupData>
 			</FormData>
 			<FormData FormOID="Form.data_types" FormRepeatKey="1">
@@ -800,6 +800,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>
@@ -828,6 +829,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>
@@ -866,6 +868,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>
@@ -894,6 +897,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>
@@ -922,6 +926,7 @@
 					<ItemData ItemOID="checkbox___1" Value="1"/>
 					<ItemData ItemOID="checkbox___2" Value="0"/>
 					<ItemData ItemOID="checkbox___3" Value="0"/>
+					<ItemData ItemOID="calc_test" Value="6"/>
 					<ItemData ItemOID="calculated_field" Value="6"/>
 					<ItemData ItemOID="required" Value="required"/>
 					<ItemData ItemOID="identifier" Value="PHI"/>


### PR DESCRIPTION
This PR should fix https://github.com/4bbakers/redcap_rsvc/issues/36.  

@4bbakers was correct during a recent meeting that the root of the XML problem is related (in part) to new eConsent.

I really saw two problems with the XML: 
1) There was an instrument that was not enabled as a survey (Consent)
2) Recent eConsent changes appear to require a few differences in the XML to enable the survey as an eConsent supported instrument - those adjustments are made in this update.

I also agree with @alewis64 and his assessment with regard to https://github.com/4bbakers/redcap_rsvc/issues/37.  I think B.3.15.1100's issues are also related to Project_1.xml.  

We'll have to keep a close eye on whether other features are impacted by Project_1.xml ... this particular XML is set in over 100 feature tests.  When I reran the test suite using the updated version, B.3.15.1100 is now passing - link is [here](https://cloud.cypress.io/projects/pvu79o/runs/1917/test-results?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%7B%22label%22%3A%22redcap_rsvc%2FFeature%20Tests%2FB%2FDirect%20Data%20Entry%20-%20Survey_15%2FB.3.15.1000.%20-%20Survey%20Participant%20List.feature%22%2C%22value%22%3A%22%5B%5C%2287fa35d7-f640-478d-ae12-f738da26e57a%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D).

