### PR TITLE
Addressed invalid '"Submit" is enabled' steps by making one manual only and remove the others because they were extraneous

### DIFF
--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0305 - eConsent status.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0305 - eConsent status.feature
@@ -68,9 +68,7 @@ Feature: C.3.24.0305. User Interface: The system shall support the e-Consent Fra
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -130,8 +128,6 @@ Feature: C.3.24.0305. User Interface: The system shall support the e-Consent Fra
         And I click on the button labeled "Leave without saving changes" in the dialog box
         Then I should see the "Completed Survey Response" icon for the "Consent" longitudinal instrument on event "Event 1"
 
-        Then I should see the button labeled "Submit" is enabled
-
         When I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
@@ -173,9 +169,7 @@ Feature: C.3.24.0305. User Interface: The system shall support the e-Consent Fra
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0405 - eConsent goverend snapshot.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0405 - eConsent goverend snapshot.feature
@@ -65,9 +65,7 @@ Feature:  C.3.24.0405. User Interface: The system shall support the e-Consent Fr
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0505. - eConsent download PDF.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0505. - eConsent download PDF.feature
@@ -64,9 +64,7 @@ Feature: C.3.24.0505. User Interface: The system shall support the e-Consent Fra
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0605 - eConsent edit.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0605 - eConsent edit.feature
@@ -67,9 +67,7 @@ Feature: User Interface: The e-Consent framework shall support editing of respon
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -131,9 +129,7 @@ Feature: User Interface: The e-Consent framework shall support editing of respon
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0705 - eConsent Certification Page.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0705 - eConsent Certification Page.feature
@@ -49,7 +49,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to pro
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
+        #Manual: Then I should see the button labeled "Submit" is enabled
 
         When I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0805 - eConsent repeat.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0805 - eConsent repeat.feature
@@ -92,9 +92,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -133,9 +131,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -172,9 +168,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -210,9 +204,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -254,9 +246,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"
@@ -295,9 +285,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for re
         And I should see the button labeled "Submit" is disabled
 
         When I check the checkbox labeled "I certify that all of my information in the document above is correct."
-        Then I should see the button labeled "Submit" is enabled
-
-        When I click on the button labeled "Submit"
+        And I click on the button labeled "Submit"
         Then I should see "Thank you for taking the survey."
 
         When I click on the button labeled "Close survey"


### PR DESCRIPTION
@4bbakers, we discussed this on our call this morning.  The catalyst for these changes is that `I should see the button labeled "Submit" is enabled` is not a valid automated test step.  Let me know if you have any questions.