### PR TITLE
Standardized manual only language

### DIFF
--- a/Feature Tests/B/Assign User Rights_6/B.2.6.300 - Data Export Rights.feature
+++ b/Feature Tests/B/Assign User Rights_6/B.2.6.300 - Data Export Rights.feature
@@ -165,7 +165,7 @@ Feature: Project Level:  The system shall allow instrument level data export rig
         # And I should NOT see "ptname"
         # And I should NOT see "identifier"
         # And I should NOT see "identifier2"
-        #M: Close csv file
+        #Manual: Close csv file
 
         And I logout
 
@@ -194,7 +194,7 @@ Feature: Project Level:  The system shall allow instrument level data export rig
         # And I should NOT see "ptname"
         # And I should NOT see "identifier"
         # And I should NOT see "identifier2"
-        #M: Close csv file
+        #Manual: Close csv file
         And I logout
 
         #SETUP

--- a/Feature Tests/B/Branching Logic_9/B.4.9.0100. - Branching Logic.feature
+++ b/Feature Tests/B/Branching Logic_9/B.4.9.0100. - Branching Logic.feature
@@ -25,7 +25,7 @@ Feature: B.4.9.0100. User Interface: The system shall support branching logic fo
         And I should see the field labeled "Calculated Field"
         And I should see the field labeled "Multiple Choice dropdown Auto"
         And I should see the field labeled "Multiple Choice Dropdown Manual"
-        #M: Close the survey page
+        #Manual: Close the survey page
 
         #FUNCTIONAL_REQUIREMENT: data entry mode
         Given I return to the REDCap page I opened the survey from
@@ -33,7 +33,7 @@ Feature: B.4.9.0100. User Interface: The system shall support branching logic fo
         And I click on the button labeled "Add new record for the arm selected above"
         And I click the bubble to add a record for the "Data Types" longitudinal instrument on event "Event 1"
 
-        #MANUAL: These confirmation windows are automatically accepted on automated side
+        #Manual: These confirmation windows are automatically accepted on automated side
         Then I should see an alert box with the following text: 'ERASE THE VALUE OF THE FIELD "ptname" ?'
         #And I click on the button labeled "OK" in the alert box
         Then I should see an alert box with the following text: 'ERASE THE VALUE OF THE FIELD "textbox" ?'
@@ -87,7 +87,7 @@ Feature: B.4.9.0100. User Interface: The system shall support branching logic fo
         And I should see the field labeled "Calculated Field"
         And I should see the field labeled "Multiple Choice dropdown Auto"
         And I should see the field labeled "Multiple Choice Dropdown Manual"
-        #M: Close tab
+        #Manual: Close tab
 
         #FUNCTIONAL_REQUIREMENT: data entry mode
         Given I return to the REDCap page I opened the survey from
@@ -136,7 +136,7 @@ Feature: B.4.9.0100. User Interface: The system shall support branching logic fo
 
         When I uncheck the checkbox labeled "Checkbox3"
         Then I should NOT see the field labeled "Required"
-        #M: Close the survey page
+        #Manual: Close the survey page
 
         ##VERIFY_LOG
         Given I return to the REDCap page I opened the survey from

--- a/Feature Tests/B/Data Access Groups_10/B.2.10.0400. - User and Record Restrictions.feature
+++ b/Feature Tests/B/Data Access Groups_10/B.2.10.0400. - User and Record Restrictions.feature
@@ -179,7 +179,7 @@ Feature: B.2.10.0400. User Interface: The system shall provide the ability to re
         Then I should see "You may now close this tab/window"
 
         Given I return to the REDCap page I opened the survey from
-        #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+        #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
         #And I click on the button labeled "Leave without saving changes" in the dialog box
         ##VERIFY_LOG:
         And I click on the link labeled "Logging"

--- a/Feature Tests/B/Data Import_16/B.3.16.0100. - Import Templates - Columns & Rows.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0100. - Import Templates - Columns & Rows.feature
@@ -24,7 +24,7 @@ Feature: User Interface: The system shall support the ability to download two ve
     ##VERIFY
     And the downloaded CSV with filename "B316100100_ImportTemplate_yyyy-mm-dd.csv" has the header below
       | record_id | name | email | text_validation_complete | ptname | bdate | role | notesbox | multiple_dropdown_auto | multiple_dropdown_manual | multiple_radio_auto | radio_button_manual | checkbox___1 | checkbox___2 | checkbox___3 | required | identifier_ssn | identifier_phone | slider | date_time_hh_mm | date_time_hh_mm_ss | data_types_complete | data_dictionary_form_complete | phone | demo_branching_complete |  |
-    #M: close csv file
+    #Manual: close csv file
 
     #FUNCTIONAL REQUIREMENT
     ##ACTION Data Import Template (with records in columns)
@@ -32,7 +32,7 @@ Feature: User Interface: The system shall support the ability to download two ve
     Then I should see "Download your Data Import Template (with records in columns)"
     And I click on the link labeled "Download your Data Import Template" near "with records in columns" to download a file
     Then I should see a downloaded file named "B316100100_ImportTemplate_yyyy-mm-dd.csv"
-    #M: close csv file
+    #Manual: close csv file
 
     ##VERIFY
     And the downloaded CSV with filename "B316100100_ImportTemplate_yyyy-mm-dd.csv" has the header and rows below

--- a/Feature Tests/B/Data Import_16/B.3.16.0800. - Repeat Instrument Import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0800. - Repeat Instrument Import.feature
@@ -22,7 +22,7 @@ Feature: User Interface: The system shall require the repeating instrument and i
     When I click on the button labeled "Move project to production"
     And I click on the radio labeled "Delete ALL data in the project" in the dialog box
     And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
-    #M: Will have to accept confirmation window "And I click on the button labeled "Ok" in the pop-up box"
+    #Manual: Will have to accept confirmation window "And I click on the button labeled "Ok" in the pop-up box"
     Then I see Project status: "Production"
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Data Import_16/B.3.16.0900. - Import Restrictions.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.0900. - Import Restrictions.feature
@@ -47,7 +47,7 @@ Feature: User Interface: The system shall not allow data to be changed on locked
     #VERIFY_LOG
     When I click on the link labeled "Logging"
     Then I should see a table header and rows containing the following values in the logging table:
-      #M: should not see anything was imported after record was locked
+      #Manual: should not see anything was imported after record was locked
       | Username   | Action               | List of Data Changes      |
       | test_admin | Lock/Unlock Record 1 | Action Lock entire record |
 #End

--- a/Feature Tests/B/Data Import_16/B.3.16.1400. - Background data import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1400. - Background data import.feature
@@ -23,7 +23,7 @@ Feature: User Interface: The system shall allow data to be uploaded as backgroun
         Then I should see a table header and rows containing the following values in a table:
             | Status     | Original Filename              | Records Provided                  |
             | Queued     | BigDataTestProjectbadDATA.csv  | 75 |
-        ##M this may take several minutes
+        #Manual: this may take several minutes
 
         Given I click on the link labeled "Record Status Dashboard"
         Then I should see a table header and rows containing the following values in the record status dashboard table:
@@ -33,7 +33,7 @@ Feature: User Interface: The system shall allow data to be uploaded as backgroun
             | 5         |        |
             | 6         |        |
         And I should see all records are in an unverified status
-        ##M note Records were skipped, user receives email with link to the "View background Imports" where they can click the View details button where they can either Download list of all errors or Download records/data that did not import
+        #Manual: note Records were skipped, user receives email with link to the "View background Imports" where they can click the View details button where they can either Download list of all errors or Download records/data that did not import
 
         #VERIFY
         When I click on the link labeled "Logging"

--- a/Feature Tests/B/Data Import_16/B.3.16.1600. - Background erorr report.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1600. - Background erorr report.feature
@@ -24,7 +24,7 @@ Feature: User Interface: The system shall report background process data import 
         Then I should see a table header and rows containing the following values in a table:
             | Status     | Original Filename              | Records Provided                  |
             | Queued     | BigDataTestProjectbadDATA.csv  | 75 |
-        ##M this may take several minutes
+        #Manual: this may take several minutes
 
         Given I click on the link labeled "Record Status Dashboard"
         Then I should see a table header and rows containing the following values in a table:
@@ -34,7 +34,7 @@ Feature: User Interface: The system shall report background process data import 
             | 5         |        |
             | 6         |        |
         And I should see all records are in an unverified status
-        ##M note Records were skipped, user receives email with link to the "View background Imports" where they can click the View details button where they can either Download list of all errors or Download records/data that did not import
+        #Manual: note Records were skipped, user receives email with link to the "View background Imports" where they can click the View details button where they can either Download list of all errors or Download records/data that did not import
 
         #VERIFY
         When I click on the link labeled "Logging"

--- a/Feature Tests/B/Data Import_16/B.3.16.1700. - export error report.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.1700. - export error report.feature
@@ -24,7 +24,7 @@ Feature: User Interface: The system shall report background process data import 
         Then I should see a table header and rows containing the following values in a table:
             | Status     | Original Filename              | Records Provided                  |
             | Queued     | BigDataTestProjectbadDATA.csv  | 75 |
-        ##M this may take several minutes
+        #Manual: this may take several minutes
 
         Given I click on the link labeled "Record Status Dashboard"
         Then I should see a table header and rows containing the following values in a table:
@@ -34,7 +34,7 @@ Feature: User Interface: The system shall report background process data import 
             | 5         |        |
             | 6         |        |
         And I should see all records are in an unverified status
-        ##M note Records were skipped, user receives email with link to the "View background Imports" where they can click the View details button where they can either Download list of all errors or Download records/data that did not import
+        #Manual: note Records were skipped, user receives email with link to the "View background Imports" where they can click the View details button where they can either Download list of all errors or Download records/data that did not import
 
         #VERIFY
         When I click on the link labeled "Logging"

--- a/Feature Tests/B/Data Import_16/B.3.16.2100. - Stop background import.feature
+++ b/Feature Tests/B/Data Import_16/B.3.16.2100. - Stop background import.feature
@@ -20,7 +20,7 @@ Feature: User Interface: The system shall provide the ability for the user impor
         Then I should see "File was uploaded and will be processed soon"
         And I click on the button labeled "Close"
         And I wait for background processes to finish
-        ##M this may take several minutes while the system analyzes for errors
+        #Manual: this may take several minutes while the system analyzes for errors
 
         And I click on the button labeled "Halt import"
         Then I should see "Halt this background import?"

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0100. - Enable Instrument as Survey.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0100. - Enable Instrument as Survey.feature
@@ -48,7 +48,7 @@ Feature: User Interface: Survey Project Settings: The system shall support enabl
     Then I should see "Thank you for taking the survey"
     And I click on the button labeled "Close survey"
 
-    #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+    #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
     #And I click on the button labeled "Leave without saving changes" in the dialog box
 
     ##VERIFY_DE

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0400. - Open Survey from Form.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0400. - Open Survey from Form.feature
@@ -39,7 +39,7 @@ Feature: User Interface: Survey Distribution: The system shall provide a survey 
     Then I should see "Thank you for taking the survey"
     And I click on the button labeled "Close survey"
 
-    #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+    #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
     #And I click on the button labeled "Leave without saving changes" in the dialog box
 
     #FUNCTIONAL REQUIREMENT

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0800. - Edit Survey Responses.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0800. - Edit Survey Responses.feature
@@ -47,7 +47,7 @@ Feature: User Interface: The system shall allow submitted survey responses to be
 
     When I click on the button labeled "Close survey"
 
-    #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+    #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
     #And I click on the button labeled "Leave without saving changes"
 
     Given I return to the REDCap page I opened the survey from

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0900. - Survey Response Status.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.0900. - Survey Response Status.feature
@@ -51,8 +51,8 @@ Feature: User Interface: The system shall support the following statuses for sur
         Given I click on the button labeled "Save & Return Later"
         And I click on the button labeled "Close" in the dialog box
 
-        #M: Close browser tab
-        #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+        #Manual: Close browser tab
+        #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
         #And I click on the button labeled "Leave without saving changes" in the dialog box
 
         When I return to the REDCap page I opened the survey from
@@ -74,7 +74,7 @@ Feature: User Interface: The system shall support the following statuses for sur
         And I click on the button labeled "Close survey"
 
         ##VERIFY_RSD
-        #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+        #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
         # When I click on the button labeled "Leave without saving changes"
 
         Given I return to the REDCap page I opened the survey from

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1100. - Survey Response Tracking.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1100. - Survey Response Tracking.feature
@@ -44,7 +44,7 @@ Feature: User Interface: Survey Project Settings: The system shall support track
 
     ##VERIFY_RSD
     Given I return to the REDCap page I opened the survey from
-    #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+    #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
     #And I click on the button labeled "Leave without saving changes" in the dialog box
     And I click on the link labeled "Survey Distribution Tools"
     When I click on the tab labeled "Participant List"

--- a/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1200. - Disabled Survey Behavior.feature
+++ b/Feature Tests/B/Direct Data Entry - Survey_15/B.3.15.1200. - Disabled Survey Behavior.feature
@@ -72,7 +72,7 @@ Feature: User Interface: Survey Project Settings: The system shall delete all su
    
     ##VERIFY_DE
     Given I return to the REDCap page I opened the survey from
-    #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+    #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
     #And I click on the button labeled "Leave without saving changes" in the dialog box
     When I click on the link labeled "Data Exports, Reports, and Stats"
     Then I should see a table row containing the following values in the reports table:
@@ -103,7 +103,7 @@ Feature: User Interface: Survey Project Settings: The system shall delete all su
       | Record ID | Event Name             | Repeat Instrument | Repeat Instance | Data Access Group | Survey Identifier | Name            |
       | 1         | Event 1 (Arm 1: Arm 1) |                   |                 |                   |                   | B.3.15.1200.100 |
 
-    #MANUAL: Note that "text_validation_timestamp" is the column VARIABLE name used if Text Validation instrument was enabled as survey.
+    #Manual: Note that "text_validation_timestamp" is the column VARIABLE name used if Text Validation instrument was enabled as survey.
     # Cannot look for "Survey Timestamp" because that same LABEL is used for all survey timestamp columns.
     And I should NOT see "text_validation_timestamp"
 
@@ -111,7 +111,7 @@ Feature: User Interface: Survey Project Settings: The system shall delete all su
     Given I click on the link labeled "Survey Distribution Tools"
     And I click on the tab labeled "Participant List"
 
-    #MANUAL: We are verifying that you do NOT see "Text Validation" in the dropdown labeled "Participant List".
+    #Manual: We are verifying that you do NOT see "Text Validation" in the dropdown labeled "Participant List".
     # For comparison, see line 43 where "Text Validation" is included in this list ...
     Then I should see the dropdown field labeled "Participant List" with the options below
       | "Consent" - Event 1 (Arm 1: Arm 1)     |

--- a/Feature Tests/B/Export Data_21/B.5.21.0100. - Export PHI.feature
+++ b/Feature Tests/B/Export Data_21/B.5.21.0100. - Export PHI.feature
@@ -149,7 +149,7 @@ Feature: User Interface: The system shall support the ability to identify data a
     When I click on the button labeled "Submit"
     #And I click on the button labeled "Close survey"
 
-    #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+    #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
 
     Given I return to the REDCap page I opened the survey from
     And I click on the button labeled "Leave without saving changes" in the dialog box
@@ -170,7 +170,7 @@ Feature: User Interface: The system shall support the ability to identify data a
 
     Given I click on the download icons to receive the files for the "CSV / Microsoft Excel (raw data)" format in the dialog box
     ##VERIFY:
-    #MUser can see all variables with dates shifted ([data_types_timestamp]=! today) AND ([date_ymd]=! today) AND ([date_ymd_hmss]=! today)
+    #Manual: User can see all variables with dates shifted ([data_types_timestamp]=! today) AND ([date_ymd]=! today) AND ([date_ymd_hmss]=! today)
 
     Then I should see the latest downloaded "csv" file containing the headings below
       | record_id | redcap_repeat_instrument | redcap_repeat_instance | redcap_data_access_group | redcap_survey_identifier | data_types_timestamp | ptname | textbox | radio | notesbox | identifier | identifier_2 | date_ymd | datetime_ymd_hmss | data_types_complete |
@@ -178,7 +178,7 @@ Feature: User Interface: The system shall support the ability to identify data a
     And I verify the date in column labeled "date_ymd" for record "5" has shifted today's date in the latest downloaded "csv"
     And I verify the datetime in column labeled "datetime_ymd_hmss" for record "5" has shifted today's date in the latest downloaded "csv"
 
-    #M: Close the report & refresh page
+    #Manual: Close the report & refresh page
 
     And I click on the button labeled "Close" in the dialog box
     And I logout

--- a/Feature Tests/B/Export Data_21/B.5.21.0200. - Export Data to External Format.feature
+++ b/Feature Tests/B/Export Data_21/B.5.21.0200. - Export Data to External Format.feature
@@ -21,7 +21,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
 
         Given I click on the download icons to receive the files for the "CSV / Microsoft Excel (raw data)" format in the dialog box
         Then I should see a downloaded file named "B521200100_DATA_yyyy-mm-dd_hhmm.csv"
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 
@@ -35,7 +35,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
         Given I click on the download icons to receive the files for the "CSV / Microsoft Excel (labels)" format in the dialog box
         Then I should see the latest downloaded "csv" file containing the headings below
             | "Record ID" | "Event Name" | "Repeat Instrument" | "Repeat Instance" | "Data Access Group" | "Survey Identifier" | Name | Email | Complete? | Name | "Text box" | Text2 | radio | "Notes box" | "Multiple Choice Dropdown Manual" | "Multiple Choice dropdown Auto" | "Radio Button Auto" | "Radio Button Manual" | "Checkbox (choice=Checkbox1)" | "Checkbox (choice=Checkbox2)" | "Checkbox (choice=Checkbox3)" | "Calc Test" | "Calculated Field" | Signature | "File Upload" | Required | Identifier | Identifier | "Edit Field" | "date YMD" | "date MDY" | "date DMY" | "time HH:MM:SS" | "time HH:M" | "time MM:SS" | "datetime YMD HMSS" | "datetime YMD HM" | "datetime MDY HMSS" | "datetime DMY HMSS" | "Integer " | Numbers | "Numbers 1 decimal place - period as decimal " | "Numbers 1 decimal place - comma as decimal " | "Letters only" | "MRN (10 Digits)" | "MRN (generic)" | "Social Security Number (US)" | "Phone (North America)" | "Phone (Australia)" | "Phone (UK)" | "Zipcode (US)" | "Postal code 5 (France)" | "Postal Code (Australia)" | "Postal Code (Canada)" | Complete? | "Survey Timestamp" | Name | Email | Complete? | "Survey Timestamp" | Name | Email | DOB | "Signature " | Complete? |
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 
@@ -48,7 +48,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
 
         Given I click on the download icons to receive the files for the "SPSS Statistical Software" format in the dialog box
         Then I should see a downloaded file named "B521200100-TestReport_SPSS_yyyy-mm-dd_hhmm.sps"
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 
@@ -60,7 +60,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
         Then I should see a dialog containing the following text: "Data export was successful!"
         Given I click on the download icons to receive the files for the "SAS Statistical Software" format in the dialog box
         Then I should see a downloaded file named "B521200100-TestReport_SAS_yyyy-mm-dd_hhmm.sas"
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 
@@ -74,7 +74,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
         Given I click on the download icons to receive the files for the "R Statistical Software" format in the dialog box
 
         Then I should see a downloaded file named "B521200100_R_yyyy-mm-dd_hhmm.r"
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 
@@ -87,7 +87,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
 
         Given I click on the download icons to receive the files for the "Stata Statistical Software" format in the dialog box
         Then I should see a downloaded file named "B521200100-TestReport_STATA_yyyy-mm-dd_hhmm.do"
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 
@@ -100,7 +100,7 @@ Feature: User Interface: The system shall allow data to be exported in the follo
 
         Given I click on the download icons to receive the files for the "CDISC ODM (XML)" format in the dialog box
         Then I should see a downloaded file named "B521200100_CDISC_ODM_yyyy-mm-dd_hhmm.xml"
-        #Manual Close file
+        #Manual: Close file
 
         And I click on the button labeled "Close" in the dialog box
 #END

--- a/Feature Tests/B/Export Data_21/B.5.21.0300. - REDUNDANT.feature
+++ b/Feature Tests/B/Export Data_21/B.5.21.0300. - REDUNDANT.feature
@@ -24,6 +24,6 @@ Feature: User Interface: The system shall allow for exporting every field in a d
     # ##VERIFY:
     # Then I should have a "csv" file that contains the headings below
     #   | record_id | redcap_repeat_instrument | redcap_repeat_instance | redcap_data_access_group | redcap_survey_identifier | data_types_timestamp | ptname | textbox | radio | notesbox | identifier | identifier_2 | date_ymd | datetime_ymd_hmss | data_types_complete |
-    # #M: Close the report
+    # #Manual: Close the report
     # And I click on the button labeled "Close" in the dialog box
 #END

--- a/Feature Tests/B/Export Data_21/B.5.21.0500. - REDUNDANT.feature
+++ b/Feature Tests/B/Export Data_21/B.5.21.0500. - REDUNDANT.feature
@@ -153,7 +153,7 @@ Feature: User Interface: The system shall have the following data de-identificat
 #         When I click on the button labeled "Submit"
 #         #And I click on the button labeled "Close survey"
 
-#         #Manual Only: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
+#         #Manual: Surveys open in the same window (by default) in automated tests (automated tests this in B.3.15.500 - Survey Alerts and Prompts)
 
 #         Given I return to the REDCap page I opened the survey from
 #         And I click on the button labeled "Leave without saving changes" in the dialog box
@@ -174,7 +174,7 @@ Feature: User Interface: The system shall have the following data de-identificat
 
 #         Given I click on the download icons to receive the files for the "CSV / Microsoft Excel (raw data)" format in the dialog box
 #         ##VERIFY:
-#         #MUser can see all variables with dates shifted ([data_types_timestamp]=! today) AND ([date_ymd]=! today) AND ([date_ymd_hmss]=! today)
+#         #Manual: User can see all variables with dates shifted ([data_types_timestamp]=! today) AND ([date_ymd]=! today) AND ([date_ymd_hmss]=! today)
 
 #         Then I should see the latest downloaded "csv" file containing the headings below
 #             | record_id | redcap_repeat_instrument | redcap_repeat_instance | redcap_data_access_group | redcap_survey_identifier | data_types_timestamp | ptname | textbox | radio | notesbox | identifier | identifier_2 | date_ymd | datetime_ymd_hmss | data_types_complete |
@@ -182,7 +182,7 @@ Feature: User Interface: The system shall have the following data de-identificat
 #         And I verify the date in column labeled "date_ymd" for record "5" has shifted today's date in the latest downloaded "csv"
 #         And I verify the datetime in column labeled "datetime_ymd_hmss" for record "5" has shifted today's date in the latest downloaded "csv"
 
-#         #M: Close the report & refresh page
+#         #Manual: Close the report & refresh page
 
 #         And I click on the button labeled "Close" in the dialog box
 #         And I logout

--- a/Feature Tests/C/Data Quality_18/C.4.18.0200. - Data Quality create rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0200. - Data Quality create rules.feature
@@ -99,7 +99,7 @@ Feature: User Interface: The system shall support data quality rule creation.
         Then I should see a table header and rows containing the following values in a table:
             | Rule # | Rule Name | Rule Logic (Show discrepancy only if...) |
             | 4      | Integer   | [integer]='1'                            |
-        #M: refresh browser page
+        #Manual: refresh browser page
 
         #VERIFY
         And I click on the link labeled "Data Quality"
@@ -112,7 +112,7 @@ Feature: User Interface: The system shall support data quality rule creation.
 
         ##ACTION: delete rule
         When I click on the Delete icon for Data Quality Rule # "4"
-        #MANUAL: confirmation windows are automatically accepted on automated side
+        #Manual: confirmation windows are automatically accepted on automated side
         #And I click on the button labeled "OK" in the dialog box
         Then I should see a table header and rows containing the following values in a table:
             | Rule # | Rule Name | Rule Logic (Show discrepancy only if...) | Total Discrepancies |

--- a/Feature Tests/C/Data Quality_18/C.4.18.0600. - Data Quality exclude rules.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0600. - Data Quality exclude rules.feature
@@ -49,7 +49,7 @@ Feature: User Interface: The system shall support excluding discrepancies found 
             | 5 (#1) | integer = 1111111111                | Out of range | remove exclusion |
 
         And I click on the button labeled "Close" in the dialog box
-        #M: refresh the page
+        #Manual: refresh the page
 
         ##VERIFY
         Then I click on the button labeled "Clear"
@@ -84,7 +84,7 @@ Feature: User Interface: The system shall support excluding discrepancies found 
             | 5 (#1) | number = 10.000                     | Out of range | exclude |
 
         And I click on the button labeled "Close" in the dialog box
-        #M: refresh the page
+        #Manual: refresh the page
 
         ##VERIFY
         Then I click on the button labeled "Clear"

--- a/Feature Tests/C/Data Quality_18/C.4.18.0800. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0800. - REDUNDANT.feature
@@ -102,7 +102,7 @@ Feature: User Interface: The system shall support the deletion of a user defined
 #     Then I should see a table header and rows containing the following values in a table:
 #       | Rule # | Rule Name | Rule Logic (Show discrepancy only if...) |
 #       | 4      | Integer   | [integer]='1'                            |
-#     #M: refresh browser page
+#     #Manual: refresh browser page
 
 #     #VERIFY
 #     And I click on the link labeled "Data Quality"
@@ -115,7 +115,7 @@ Feature: User Interface: The system shall support the deletion of a user defined
 
 #     ##ACTION: delete rule
 #     When I click on the Delete icon for Data Quality Rule # "4"
-#     #MANUAL: confirmation windows are automatically accepted on automated side
+#     #Manual: confirmation windows are automatically accepted on automated side
 #     #And I click on the button labeled "OK" in the dialog box
 #     Then I should see a table header and rows containing the following values in a table:
 #       | Rule # | Rule Name | Rule Logic (Show discrepancy only if...) | Total Discrepancies |

--- a/Feature Tests/C/Data Quality_18/C.4.18.0900. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.0900. - REDUNDANT.feature
@@ -52,7 +52,7 @@ Feature: User Interface: The system shall support clearing discrepancies from ru
 #             | 5 (#1) | integer = 1111111111                | Out of range | remove exclusion |
 
 #         And I click on the button labeled "Close" in the dialog box
-#         #M: refresh the page
+#         #Manual: refresh the page
 
 #         ##VERIFY
 #         Then I click on the button labeled "Clear"
@@ -87,7 +87,7 @@ Feature: User Interface: The system shall support clearing discrepancies from ru
 #             | 5 (#1) | number = 10.000                     | Out of range | exclude |
 
 #         And I click on the button labeled "Close" in the dialog box
-#         #M: refresh the page
+#         #Manual: refresh the page
 
 #         ##VERIFY
 #         Then I click on the button labeled "Clear"

--- a/Feature Tests/C/Data Quality_18/C.4.18.1100. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1100. - REDUNDANT.feature
@@ -102,7 +102,7 @@ Feature: User Interface: The system shall support validating the unique event na
 #         Then I should see a table header and rows containing the following values in a table:
 #             | Rule # | Rule Name | Rule Logic (Show discrepancy only if...) |
 #             | 4      | Integer   | [integer]='1'                            |
-#         #M: refresh browser page
+#         #Manual: refresh browser page
 
 #         #VERIFY
 #         And I click on the link labeled "Data Quality"
@@ -115,7 +115,7 @@ Feature: User Interface: The system shall support validating the unique event na
 
 #         ##ACTION: delete rule
 #         When I click on the Delete icon for Data Quality Rule # "4"
-#         #MANUAL: confirmation windows are automatically accepted on automated side
+#         #Manual: confirmation windows are automatically accepted on automated side
 #         #And I click on the button labeled "OK" in the dialog box
 #         Then I should see a table header and rows containing the following values in a table:
 #             | Rule # | Rule Name | Rule Logic (Show discrepancy only if...) | Total Discrepancies |

--- a/Feature Tests/C/Data Quality_18/C.4.18.1200. - REDUNDANT.feature
+++ b/Feature Tests/C/Data Quality_18/C.4.18.1200. - REDUNDANT.feature
@@ -52,7 +52,7 @@ Feature: User Interface: The system shall support removal of exclusion of discre
 #             | 5 (#1) | integer = 1111111111                | Out of range | remove exclusion |
 
 #         And I click on the button labeled "Close" in the dialog box
-#         #M: refresh the page
+#         #Manual: refresh the page
 
 #         ##VERIFY
 #         Then I click on the button labeled "Clear"
@@ -87,7 +87,7 @@ Feature: User Interface: The system shall support removal of exclusion of discre
 #             | 5 (#1) | number = 10.000                     | Out of range | exclude |
 
 #         And I click on the button labeled "Close" in the dialog box
-#         #M: refresh the page
+#         #Manual: refresh the page
 
 #         ##VERIFY
 #         Then I click on the button labeled "Clear"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0205 - eConsent footer.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0205 - eConsent footer.feature
@@ -167,7 +167,7 @@ Feature: User Interface: The system shall support the e-Consent Framework abilit
         When I click on the file link for record "1" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with the following values in the header: "PID xxxx - LastName"
         And I should have a pdf file with the following values in the footer: "Type: Participant"
-        #M: Close document
+        #Manual: Close document
 
 
         ##VERIFY_Logging

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0305 - eConsent status.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0305 - eConsent status.feature
@@ -197,7 +197,7 @@ Feature: C.3.24.0305. User Interface: The system shall support the e-Consent Fra
 
         When I click on the file link for record "2" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with the following values in the signature field "signature"
-        #M: Close document
+        #Manual: Close document
 
 
         ##VERIFY_Logging

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0405 - eConsent goverend snapshot.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0405 - eConsent goverend snapshot.feature
@@ -85,7 +85,7 @@ Feature:  C.3.24.0405. User Interface: The system shall support the e-Consent Fr
         When I click on the file link for record "1" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with the following values in the header: "PID xxxx - LastName"
         And I should have a pdf file with the following values in the footer: "Type: Participant"
-        #M: Close document
+        #Manual: Close document
 
 
         ##VERIFY_Logging

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0505. - eConsent download PDF.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0505. - eConsent download PDF.feature
@@ -84,7 +84,7 @@ Feature: C.3.24.0505. User Interface: The system shall support the e-Consent Fra
         When I click on the file link for record "1" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with the following values in the header: "PID xxxx - LastName"
         And I should have a pdf file with the following values in the footer: "Type: Participant"
-        #M: Close document
+        #Manual: Close document
 
 
         ##VERIFY_Logging

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0605 - eConsent edit.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0605 - eConsent edit.feature
@@ -174,7 +174,7 @@ Feature: User Interface: The e-Consent framework shall support editing of respon
         When I click on the file link for record "2" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with "FirstName" into the input field labeled "First Name"
         #NOTE: Edited version with "NewFirstName" is NOT in the file repository.
-        #M: Close document
+        #Manual: Close document
 
         ##VERIFY_Logging
         When I click on the link labeled "Logging"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.0705 - eConsent Certification Page.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.0705 - eConsent Certification Page.feature
@@ -73,7 +73,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to pro
         When I click on the file link for record "2" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with "FirstName" into the input field labeled "First Name"
         #NOTE: Edited version with "NewFirstName" is NOT in the file repository.
-        #M: Close document
+        #Manual: Close document
 
         ##VERIFY_Logging
         When I click on the link labeled "Logging"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1200. - eConsent header.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1200. - eConsent header.feature
@@ -80,7 +80,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to cre
 
         When I click on the file link for record "1" Survey "(Event 1 (Arm 1: Arm 1))"
         Then I should have a pdf file with the following values in the header: "PID xxxx - LastName"
-        #M: Close document
+        #Manual: Close document
 
         ##VERIFY_Logging
         ##e-Consent Framework not used, and PDF Snapshot is used

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1500. - eConsent version control.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1500. - eConsent version control.feature
@@ -112,7 +112,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for ve
 
         When I click on the file link for record "1" Survey "(Event 1 (Arm 1: Arm 1))"
         Then I should see "This is my test 1 consent form"
-    #M: Close document
+    #Manual: Close document
 
     Scenario: C.3.24.1500.200 e-Consent create unique version using Inline PDF
         #Add consent form version via file upload
@@ -223,7 +223,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for ve
 
         When I click on the file link for record "2" Survey "(Event 1 (Arm 1: Arm 1))"
         Then I should see "consent.pdf"
-    #M: Close document
+    #Manual: Close document
 
     Scenario: C.3.24.1500.300 Disable version
         #Add consent form version via file upload
@@ -264,7 +264,7 @@ Feature: User Interface: The system shall support the e-Consent Framework for ve
     Scenario: C.3.24.1500.400 View historical version
         When I click on the file link "consent.pdf" in the dialog box
         Then I should see "consent.pdf"
-        #M: Close document
+        #Manual: Close document
 
         When I click on the button labeled "Close" in the dialog box
         Then I should NOT see "Consent form vtest 2" for the survey labeled "Participant Consent"
@@ -320,5 +320,5 @@ Feature: User Interface: The system shall support the e-Consent Framework for ve
 
         When I click on the file link for record "3" Survey "(Event 1 (Arm 1: Arm 1))"
         Then I should NOT see "consent.pdf"
-#M: Close document
+#Manual: Close document
 #END

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1600. - eConsent field.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1600. - eConsent field.feature
@@ -97,7 +97,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to pla
 
       When I click on the file link for record "1" Survey "(Event 1 (Arm 1: Arm 1))"
       Then I should see "This is my test 1 consent form"
-   #M: Close document
+   #Manual: Close document
 
    Scenario: C.3.24.1600.200 e-Consent create unique version using Inline PDF
       #Add consent form version via file upload
@@ -188,5 +188,5 @@ Feature: User Interface: The system shall support the e-Consent Framework to pla
 
       When I click on the file link for record "2" Survey "(Event 1 (Arm 1: Arm 1))"
       Then I should see "consent.pdf"
-#M: Close document
+#Manual: Close document
 #END

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.1900. - eConsent autosave PDF.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.1900. - eConsent autosave PDF.feature
@@ -100,7 +100,7 @@ Feature: User Interface: The system shall support the e-Consent Framework to opt
       When I click on the file link for record "1" Survey "Participant Consent (Event 1 (Arm 1: Arm 1))"
       Then I should have a pdf file with the following values in the header: "PID xxxx - LastName"
       And I should have a pdf file with the following values in the footer: "Type: Participant"
-      #M: Close document
+      #Manual: Close document
 
 
       ##VERIFY_Logging

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2200. - PDF triggers.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2200. - PDF triggers.feature
@@ -188,7 +188,7 @@ Feature: User Interface: The system shall support the creation, modification, an
 
       When I click on the file link the field labeled "Participant Consent file"
       Then I should have a pdf file with the following values "Participant Consent"
-      #M: Close document
+      #Manual: Close document
 
       #Add Insturment 2's response
       When I click on the bubble labeled "Coordiantor Signature"
@@ -217,7 +217,7 @@ Feature: User Interface: The system shall support the creation, modification, an
       When I click on the file link the field labeled "Coordinator Signature file"
       Then I should have a pdf file with the following values "Participant Consent"
       And I should have a pdf file with the following values "Coordinator Signature"
-   #M: Close document
+   #Manual: Close document
 
 
    Scenario: Verification pdf saved and logged correctly

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2500. - PDF conditional logic.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2500. - PDF conditional logic.feature
@@ -122,7 +122,7 @@ Feature: User Interface: The system shall support conditional logic integration 
 
       When I click on the file link the field labeled "Participant Consent file"
       Then I should have a pdf file with the following values "Participant Consent"
-      #M: Close document
+      #Manual: Close document
 
       #Add Insturment 2's response
       When I click on the bubble labeled "Coordiantor Signature"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2700. - PDF save location.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2700. - PDF save location.feature
@@ -72,7 +72,7 @@ Feature: User Interface: The system shall support the saving PDF snapshots to sp
 
       When I click on the file link the field labeled "Participant Consent file"
       Then I should have a pdf file with the following values "Participant Consent"
-      #M: Close document
+      #Manual: Close document
 
       ##VERIFY_FiRe
       When I click on the link labeled "File Repository"

--- a/Feature Tests/C/e-Consent framework_24/C.3.24.2800. - PDF filename.feature
+++ b/Feature Tests/C/e-Consent framework_24/C.3.24.2800. - PDF filename.feature
@@ -72,7 +72,7 @@ Feature: User Interface: The system shall support the customization of the file 
 
       When I click on the file link the field labeled "Participant Consent file"
       Then I should have a pdf file with the following values "Participant Consent"
-      #M: Close document
+      #Manual: Close document
 
       ##VERIFY_FiRe
       When I click on the link labeled "File Repository"

--- a/Feature Tests/D/eDoc_28/D.3.28.0100.feature
+++ b/Feature Tests/D/eDoc_28/D.3.28.0100.feature
@@ -10,7 +10,7 @@ Feature: Control Center: The system shall support the option to configure the st
         When I click on the link labeled "Control Center"
         And I click on the link labeled "File Upload Settings "
         Then I should see "Microsoft Azure Blob Storage"
-        #M REDCap Administrators may need to work with their Azure Administrator to get the Account Name, Account Key, and Blob Container information
+        #Manual: REDCap Administrators may need to work with their Azure Administrator to get the Account Name, Account Key, and Blob Container information
         And I click on the button labeled "Save Changes"
         And I should see "Your configuration values have now been changed"
 
@@ -65,5 +65,5 @@ Feature: Control Center: The system shall support the option to configure the st
 #Manual: Close document
 
 ##VERIFY_PDF Snapshot Specific File Location
-#M REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
+#Manual: REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
 #END

--- a/Feature Tests/D/eDoc_28/D.3.28.0200.feature
+++ b/Feature Tests/D/eDoc_28/D.3.28.0200.feature
@@ -10,7 +10,7 @@ Feature: Control Center: The system shall support enabling or disabling the use 
         When I click on the link labeled "Control Center"
         And I click on the link labeled "File Upload Settings "
         Then I should see "Microsoft Azure Blob Storage"
-        #M REDCap Administrators may need to work with their Azure Administrator to get the Account Name, Account Key, and Blob Container information
+        #Manual: REDCap Administrators may need to work with their Azure Administrator to get the Account Name, Account Key, and Blob Container information
         And I click on the button labeled "Save Changes"
         And I should see "Your configuration values have now been changed"
 
@@ -65,5 +65,5 @@ Feature: Control Center: The system shall support enabling or disabling the use 
 #Manual: Close document
 
 ##VERIFY_PDF Snapshot Specific File Location
-#M REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
+#Manual: REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
 #END

--- a/Feature Tests/D/eDoc_28/D.3.28.0300.feature
+++ b/Feature Tests/D/eDoc_28/D.3.28.0300.feature
@@ -98,5 +98,5 @@ Feature: User Interface: The system shall allow project level enabling or disabl
 
 
 ##VERIFY_PDF Snapshot Specific File Location
-#M REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
+#Manual: REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
 #END

--- a/Feature Tests/D/eDoc_28/D.3.28.0400.feature
+++ b/Feature Tests/D/eDoc_28/D.3.28.0400.feature
@@ -51,5 +51,5 @@ Feature: User Interface: The system shall allow project level enabling or disabl
 
 
 ##VERIFY_PDF Snapshot Specific File Location
-#M REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
+#Manual: REDCap Administrators may need to work with their Azure Administrator to get a screenshot that the PDF file exists
 #END


### PR DESCRIPTION
@4bbakers, I noticed we used several different ways to specify manual only steps & notes.  This PR normalizes them all to use `#Manual:`.  I chose that one because it was already the most common one we were using.  Also, simply "M" seemed too cryptic (people may not immediately know what that means).   What do you think about this change?