### PR TITLE
Fixed A.3.24.0900

### DIFF
--- a/Feature Tests/A/e-Consent framework_24/A.3.24.0900. - eConsent display.feature
+++ b/Feature Tests/A/e-Consent framework_24/A.3.24.0900. - eConsent display.feature
@@ -33,11 +33,11 @@ Feature: Control Center: The system shall support the option to display or hide 
               And I click on the link labeled "A.3.24.0900.100"
               And I click on the link labeled "Designer"
               #Verify econsent framework disabled
-              Then I should see "PDF Snapshots"
+              And I should NOT see "e-Consent"
 
+              Then I should see "PDF Snapshots"
               When I click on the button labeled "PDF Snapshots"
               Then I should see "PDF Snapshots of Records"
-              And I should NOT see "e-Consent Framework"
 
        #SETUP_CONTROL_CENTER
        Scenario: #Enable e-Consent Framework


### PR DESCRIPTION
The way this button displays was changed in REDCap since this test was written.  As written it was not working because it was matching a link the e-Consent videos on the `PDF Snapshots` page.  Checking for the `e-Consent` button in the `Designer` is a more appropriate (perhaps the only) way for this test to assert that e-Consent is enabled or disabled.