### PR TITLE
Fix B.3.14.1400. - Bulk Record Delete | Fixes [4bbakers/redcap_rsvc#149]

### DIFF
--- a/Feature Tests/A/Project Setup_4/A.6.4.0100. - User Create Projects.feature
+++ b/Feature Tests/A/Project Setup_4/A.6.4.0100. - User Create Projects.feature
@@ -21,7 +21,7 @@ Feature: A.6.4.0100. Manage project creation, deletion, and settings.   Control 
     Then I should see "General Configuration"
 
     When I enter "redcap@test.instance" into the input field labeled "Email Address of REDCap Administrator"
-    And I enter "You are now creating a test project" into the textarea field labeled "Custom message when creating/copying project"
+    And I enter "You are now creating a test project" into the textarea field labeled "Custom text displayed in a popup dialog when creating/copying project"
     And I click on the button labeled "Save Changes"
     Then I should see "Your system configuration values have now been changed"
     # END: STEPS FOR ATS ###

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
@@ -187,7 +187,7 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
         And I enter "delete" into the input field labeled 'TYPE "DELETE" BELOW' in the dialog box
         And I click on the button labeled "Delete" in the dialog box
         Then I should see "Deleted forms"
-        And I should see "[event_1_arm_1] text_validation"
+        And I should see "[event_1_arm_1] data_types"
         And I should see "for 1 record(s)"
 
     Scenario:##ACTION Verify record exist ##VERIFY_RSD
@@ -202,11 +202,12 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
         When I click on the link labeled "Logging"
         Then I should see a table header and rows containing the following values in the logging table:
             | Time / Date      | Username   | Action          | List of Data Changes OR Fields Exported   |
-            | mm/dd/yyyy hh:mm | test_user1 | Update record 1 | calc_text = '' , data_types_complete = '' |
+            | mm/dd/yyyy hh:mm | test_user1 | Update record 1 | calc_test = '', data_types_complete = ''                         |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 6 | record_id = '6'                           |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 2 | record_id = '2'                           |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 5 | record_id = '5'                           |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 3 | record_id = '3'                           |
+
     #END Scenario
 
     Scenario: B.3.14.1200.400: Bulk Delete Partial Records Using Select Records from List
@@ -252,7 +253,7 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
             | mm/dd/yyyy hh:mm | test_user1 | Update record 4 | [instance = 3], checkbox(1) = unchecked, checkbox(2) = unchecked, checkbox(3) = unchecked, data_types_complete = '', required = '', date_ymd = '', datetime_ymd_hmss = '', calc_test = |
             | mm/dd/yyyy hh:mm | test_user1 | Update record 4 | [instance = 2], checkbox(1) = unchecked, checkbox(2) = unchecked, checkbox(3) = unchecked, data_types_complete = '', required = '', date_ymd = '', datetime_ymd_hmss = '', calc_test = |
             | mm/dd/yyyy hh:mm | test_user1 | Update record 4 | checkbox(1) = unchecked, checkbox(2) = unchecked, checkbox(3) = unchecked, data_types_complete = '', required = '', date_ymd = '', datetime_ymd_hmss = '', calc_test =                 |
-            | mm/dd/yyyy hh:mm | test_user1 | Update record 1 | calc_text = '' , data_types_complete = ''                                                                                                                                              |
+            | mm/dd/yyyy hh:mm | test_user1 | Update record 1 | calc_test = '', data_types_complete = ''                           |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 6 | record_id = '6'                                                                                                                                                                        |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 2 | record_id = '2'                                                                                                                                                                        |
             | mm/dd/yyyy hh:mm | test_user1 | Delete record 5 | record_id = '5'                                                                                                                                                                        |

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
@@ -92,6 +92,7 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
         When I click on the button labeled "Bulk Record Delete"
         Then I should see "Bulk Record Delete"
 
+        And I wait for 2 seconds
         When I click on the radio labeled exactly "Delete entire records"
         When I click on the radio labeled exactly "Enter a custom list of records"
         And I wait for 2 seconds
@@ -130,14 +131,21 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
 
         When I click on the button labeled "Bulk Record Delete"
         Then I should see "Bulk Record Delete"
-        And I click the bubble labeled "Delete entire records"
-        And I click the bubble labeled "Select records from a list"
-        And I select "2"
-        And I select "6"
-        And I click on the button labeled "Delete"
-        And I type "delete"
-        And I click on the button labeled "Delete"
+
+        And I wait for 2 seconds
+        When I click on the radio labeled exactly "Delete entire records"
+        And I click on the radio labeled exactly "Select records from a list"
+        Then I should see "Step 3: Select records to delete"
+
+        #Note: We need the space before the digits because REDCap has them in the label
+        Given I click on the checkbox labeled exactly " 2"
+        And I click on the checkbox labeled exactly " 6"
+        And I click on the button labeled exactly " Delete "
+
+        And I enter "delete" into the input field labeled 'TYPE "DELETE" BELOW' in the dialog box
+        And I click on the button labeled "Delete" in the dialog box
         Then I should see "Deleted 2 record(s)"
+
 
     Scenario:  ##ACTION Verify record exist ##VERIFY_RSD
         When I click on the link labeled "Record Status Dashboard"
@@ -145,8 +153,6 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
             | Record ID |
             | 1         |
             | 4         |
-            | 6         |
-        And I logout
 
     Scenario: ##VERIFY_LOG
         When I click on the link labeled "Logging"
@@ -161,16 +167,28 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
     Scenario: B.3.14.1400.300: Bulk Delete Partial Records Using Custom List
         When I click on the link labeled "Project Setup"
         And I click on the link labeled "Other Functionality"
-        Then I should see a button labeled "Bulk Record Delete"
 
-        When I click the bubble labeled "Partial delete (instrument-level data only)"
-        And I select "Data Types"
-        And I click the bubble labeled "Enter a custom list of records"
-        And I type "1" into "Step 3: Enter records to delete"
-        And I click on the button labeled "Delete"
-        And I type "delete"
-        And I click on the button labeled "Delete"
-        Then I should see "Deleted forms [event_1_arm_1] data_types for 1 record(s)"
+        When I click on the button labeled "Bulk Record Delete"
+        Then I should see "Bulk Record Delete"
+
+        When I click on the radio labeled "Partial delete (instrument-level data only)"
+        Then I should see "Arm 1: Arm 1"
+
+        Given the Event Name "Event 1", I click on the checkbox labeled "Data Types"
+        When I click on the radio labeled exactly "Enter a custom list of records"
+        And I wait for 2 seconds
+        And I enter "1" into the textarea field labeled "Step 3: Enter records to delete"
+        Then I should see "Valid list entered"
+
+        #Automated: JavaScript does not fire for the alert box unless clicked again ..
+        When I click on the radio labeled "Partial delete (instrument-level data only)"
+
+        And I click on the button labeled exactly " Delete "
+        And I enter "delete" into the input field labeled 'TYPE "DELETE" BELOW' in the dialog box
+        And I click on the button labeled "Delete" in the dialog box
+        Then I should see "Deleted forms"
+        And I should see "[event_1_arm_1] text_validation"
+        And I should see "for 1 record(s)"
 
     Scenario:##ACTION Verify record exist ##VERIFY_RSD
         When I click on the link labeled "Record Status Dashboard"
@@ -178,7 +196,7 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
             | Record ID |
             | 1         |
             | 4         |
-        And I should see "incomplete (no data saved)" for Record 1
+        And I should see the "Incomplete (no data saved)" icon for the "Data Types" instrument on event "Event 1" for record "1"
 
         ##VERIFY_LOG
         When I click on the link labeled "Logging"
@@ -194,16 +212,30 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
     Scenario: B.3.14.1200.400: Bulk Delete Partial Records Using Select Records from List
         When I click on the link labeled "Project Setup"
         And I click on the link labeled "Other Functionality"
-        Then I should see a button labeled "Bulk Record Delete"
+        When I click on the button labeled "Bulk Record Delete"
+        Then I should see "Bulk Record Delete"
 
-        When I click the bubble labeled "Partial delete (instrument-level data only)"
-        And I select "Data Types"
-        And I click the bubble labeled "Enter a custom list of records"
-        And I type "4" into "Step 3: Enter records to delete"
-        And I click on the button labeled "Delete"
-        And I type "delete"
-        And I click on the button labeled "Delete"
-        Then I should see "Deleted forms [event_1_arm_1] text_validation [event_1_arm_1] data_types [event_1_arm_1] consent for 1 record(s)"
+        When I click on the radio labeled "Partial delete (instrument-level data only)"
+        Then I should see "Arm 1: Arm 1"
+        Given the Event Name "Event 1", I click on the checkbox labeled "Text Validation"
+        Given the Event Name "Event 1", I click on the checkbox labeled "Data Types"
+        Given the Event Name "Event 1", I click on the checkbox labeled "Consent"
+        When I click on the radio labeled exactly "Enter a custom list of records"
+        And I wait for 2 seconds
+        And I enter "4" into the textarea field labeled "Step 3: Enter records to delete"
+        Then I should see "Valid list entered"
+
+        #Automated: JavaScript does not fire for the alert box unless clicked again ..
+        When I click on the radio labeled "Partial delete (instrument-level data only)"
+
+        And I click on the button labeled exactly " Delete "
+        And I enter "delete" into the input field labeled 'TYPE "DELETE" BELOW' in the dialog box
+        And I click on the button labeled "Delete" in the dialog box
+        Then I should see "Deleted forms"
+        And I should see "[event_1_arm_1] text_validation"
+        And I should see "[event_1_arm_1] data_types"
+        And I should see "[event_1_arm_1] consent"
+        And I should see "for 1 record(s)"
 
     Scenario:##ACTION Verify record exist ##VERIFY_RSD
         When I click on the link labeled "Record Status Dashboard"
@@ -211,7 +243,7 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
             | Record ID |
             | 1         |
             | 4         |
-        And I should see "incomplete (no data saved)" for Record 4
+        And I should see the "Incomplete (no data saved)" icon for the "Data Types" instrument on event "Event 1" for record "4"
 
         ##VERIFY_LOG
         When I click on the link labeled "Logging"

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
@@ -218,9 +218,10 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
 
         When I click on the radio labeled "Partial delete (instrument-level data only)"
         Then I should see "Arm 1: Arm 1"
+
         Given the Event Name "Event 1", I click on the checkbox labeled "Text Validation"
-        Given the Event Name "Event 1", I click on the checkbox labeled "Data Types"
-        Given the Event Name "Event 1", I click on the checkbox labeled "Consent"
+        And the Event Name "Event 1", I click on the checkbox labeled "Data Types"
+        And the Event Name "Event 1", I click on the checkbox labeled "Consent"
         When I click on the radio labeled exactly "Enter a custom list of records"
         And I wait for 2 seconds
         And I enter "4" into the textarea field labeled "Step 3: Enter records to delete"

--- a/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
+++ b/Feature Tests/B/Direct Data Entry - Data Collection Instrument_14/B.3.14.1400. - Bulk Record Delete.feature
@@ -92,12 +92,18 @@ Feature: The system shall support Bulk Delete functionality, allowing users to d
         When I click on the button labeled "Bulk Record Delete"
         Then I should see "Bulk Record Delete"
 
-        When I click the bubble labeled "Delete entire records"
-        And I click the bubble labeled "Enter a custom list of records"
-        And I type "3,5" into "Step 3: Enter records to delete"
-        And I click on the button labeled "Delete"
-        And I type "delete"
-        And I click on the button labeled "Delete"
+        When I click on the radio labeled exactly "Delete entire records"
+        When I click on the radio labeled exactly "Enter a custom list of records"
+        And I wait for 2 seconds
+        And I enter "3,5" into the textarea field labeled "Step 3: Enter records to delete"
+        Then I should see "Valid list entered"
+
+        #Automated: JavaScript does not fire for the alert box unless clicked again ..
+        When I click on the radio labeled exactly "Delete entire records"
+        And I click on the button labeled exactly " Delete "
+
+        And I enter "delete" into the input field labeled 'TYPE "DELETE" BELOW' in the dialog box
+        And I click on the button labeled "Delete" in the dialog box
         Then I should see "Deleted 2 record(s)"
 
     Scenario:  ##ACTION Verify record exist

--- a/Feature Tests/B/Online Designer_7/B.6.7.0100. - New Instruments via Data Dictionary.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0100. - New Instruments via Data Dictionary.feature
@@ -16,7 +16,7 @@ Feature: Design forms Using Data Dictionary and Online Designer
         #FUNCTIONAL_REQUIREMENT
         ##ACTION: Download data dictionary
         When I click on the link labeled "Dictionary"
-        And I click on the link labeled "Download the current Data Dictionary" to download a file
+        And I click on the button labeled "Download Data Dictionary" to download a file
 
         ##VERIFY
         Then I should see the latest downloaded "csv" file containing the headings and rows below

--- a/Feature Tests/B/Online Designer_7/B.6.7.0100. - New Instruments via Data Dictionary.feature
+++ b/Feature Tests/B/Online Designer_7/B.6.7.0100. - New Instruments via Data Dictionary.feature
@@ -69,7 +69,9 @@ Feature: Design forms Using Data Dictionary and Online Designer
         ##VERIFY
         Then I should see "Errors found in your Data Dictionary:"
         And I click on the button labeled "RETURN TO PREVIOUS PAGE"
-        Then I should see "Steps for making project changes"
+        Then I should see "STEP 1"
+        And I should see "STEP 2"
+        And I should see "STEP 3"
 
         #VERIFY_LOG
         When I click on the link labeled "Logging"

--- a/Feature Tests/B/Project Setup_4/B.6.4.1000. - Project Copy.feature
+++ b/Feature Tests/B/Project Setup_4/B.6.4.1000. - Project Copy.feature
@@ -13,7 +13,7 @@ Feature: User Interface: General: The system shall support the ability to copy t
     Then I should see "General Configuration"
 
     When I enter "redcap@test.instance" into the input field labeled "Email Address of REDCap Administrator"
-    And I enter "You are now creating a test project" into the textarea field labeled "Custom message when creating/copying project"
+    And I enter "You are now creating a test project" into the textarea field labeled "Custom text displayed in a popup dialog when creating/copying project"
     And I click on the button labeled "Save Changes"
     Then I should see "Your system configuration values have now been changed"
 


### PR DESCRIPTION
Now passing per cloud run [2025](https://cloud.cypress.io/projects/pvu79o/runs/2053/test-results?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%7B%22label%22%3A%22redcap_rsvc%2FFeature%20Tests%2FB%2FDirect%20Data%20Entry%20-%20Data%20Collection%20Instrument_14%2FB.3.14.1400.%20-%20Bulk%20Record%20Delete.feature%22%2C%22value%22%3A%22%5B%5C%226e02f41a-eb07-414d-94a8-1b213c56270d%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D).

Note that this feature will only work with [RCTF v1.0.116 update](https://github.com/aldefouw/rctf/tree/v1.0.116).

If I didn't know better, I would have assumed this was written by Courtney Howell originally considering the use of "calc_text" in place of the project's actual variable name "calc_test" 😆.  (See original line 181 and 217 - now fixed.)

There is some clean up to do with wait statements in the long run but it's good for now.