### PR TITLE
Correct C.2.19.200 to match funcational requirement

### DIFF
--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0100. - Lock status.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0100. - Lock status.feature
@@ -110,3 +110,5 @@ Feature: User Interface: The E-signature and Locking Management tool shall displ
         When I click on the link labeled "Data Types"
         Then I should see "Data Types"
         And I should see "Lock this instrument?"
+        
+        #END

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0200. - Lock form display.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0200. - Lock form display.feature
@@ -23,9 +23,9 @@ Feature: User Interface: The tool shall only display forms that are designated t
     Then I should see a table header and rows containing the following values in a table:
       | Display the Lock option for this instrument? | Data Collection Instrument | Also display E-signature option on instrument? |                           |
       | [✓]                                          | Text Validation            | [ ]                                            | Notes Box & "Save" button |
-      | checkbox                                     | Data Type                  | [ ]                                            | Notes Box & "Save" button |
+      | [✓]                                          | Data Type                  | [ ]                                            | Notes Box & "Save" button |
       | [✓]                                          | Survey                     | [ ]                                            | Notes Box & "Save" button |
-      | checkbox                                     | Consent                    | [ ]                                            | Notes Box & "Save" button |
+      | [✓]                                          | Consent                    | [ ]                                            | Notes Box & "Save" button |
 
   Scenario: ##VERIFY: form display lock function
     When I click on the link labeled "Record Status Dashboard"
@@ -34,7 +34,7 @@ Feature: User Interface: The tool shall only display forms that are designated t
     And I should see a checkbox labeled "Lock this instrument?" that is unchecked
     When I click on the checkbox for the field labeled "Lock this instrument?"
     And I click on the button labeled "Save & Exit Form"
-    Then I should see "Record HomeS Page"
+    Then I should see "Record Home Page"
 
   Scenario: ##VERIFY: form NOT display lock function
     When I click on the link labeled "Record Status Dashboard"

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0200. - Lock form display.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0200. - Lock form display.feature
@@ -1,98 +1,46 @@
 Feature: User Interface: The tool shall only display forms that are designated to be locked.
-
     As a REDCap end user
     I want to see that Record locking and E-signatures is functioning as expected
 
-    Scenario: C.2.19.100.100 Display locked and e-signed status
-
+  Scenario: C.2.19.200.100 Display forms that are designated
         #SETUP
-        Given I login to REDCap with the user "Test_Admin"
+    Given I login to REDCap with the user "Test_Admin"
         #Manual: Append project name with the current version (i.e. "X.X.X.XXX.XXX - LTS X.X.X")
-        And I create a new project named "C.2.19.100.100" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
+    And I create a new project named "C.2.19.200.100" by clicking on "New Project" in the menu bar, selecting "Practice / Just for fun" from the dropdown, choosing file "Project_1.xml", and clicking the "Create Project" button
 
-        #SETUP_PRODUCTION
-        When I click on the link labeled "Project Setup"
-        And I click on the button labeled "Move project to production"
-        And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
-        And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
-        Then I should see Project status: "Production"
+  Scenario: #SETUP_PRODUCTION
+    When I click on the link labeled "Project Setup"
+    And I click on the button labeled "Move project to production"
+    And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
+    And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
+    Then I should see Project status: "Production"
 
-        #SETUP
-        When I click on the link labeled "Customize & Manage Locking/E-signatures"
-        And I click on the button labeled "I understand. Let me make changes" in the dialog box
-        Then I should see a table header and rows containing the following values in a table:
-            | Display the Lock option for this instrument? | Data Collection Instrument | Also display E-signature option on instrument? |                           |
-            | [✓]                                          | Text Validation            | [ ]                                            | Notes Box & "Save" button |
-            | [✓]                                          | Data Type                  | [ ]                                            | Notes Box & "Save" button |
-            | [✓]                                          | Survey                     | [ ]                                            | Notes Box & "Save" button |
-            | [✓]                                          | Consent                    | [ ]                                            | Notes Box & "Save" button |
+  Scenario: #SETUP form lock to display
+        #FUNCTIONAL REQUIREMENT  C.2.19.200.100 
+    When I click on the link labeled "Customize & Manage Locking/E-signatures"
+    And I click on the button labeled "I understand. Let me make changes" in the dialog box
+    And for the Column Name "Display the Lock option for this instrument?", I check the checkbox within the Record Locking Customization table for the Data Collection Instrument named "Data Type"
+    Then I should see a table header and rows containing the following values in a table:
+      | Display the Lock option for this instrument? | Data Collection Instrument | Also display E-signature option on instrument? |                           |
+      | [✓]                                          | Text Validation            | [ ]                                            | Notes Box & "Save" button |
+      | checkbox                                     | Data Type                  | [ ]                                            | Notes Box & "Save" button |
+      | [✓]                                          | Survey                     | [ ]                                            | Notes Box & "Save" button |
+      | checkbox                                     | Consent                    | [ ]                                            | Notes Box & "Save" button |
 
+  Scenario: ##VERIFY: form display lock function
+    When I click on the link labeled "Record Status Dashboard"
+    And I locate the bubble for the "Text Validation" instrument on event "Event 1" for record ID "1" and click on the bubble
+    Then I should see "Text Validation"
+    And I should see a checkbox labeled "Lock this instrument?" that is unchecked
+    When I click on the checkbox for the field labeled "Lock this instrument?"
+    And I click on the button labeled "Save & Exit Form"
+    Then I should see "Record HomeS Page"
 
-        #FUNCTIONAL REQUIREMENT
-        ##ACTION Lock Record Custom Text
-        When I enter "Test custom text" into the Notes Box field for the Data Collection Instrument labeled "Text Validation"
-        And I click on the button labeled "Save" for the Data Collection Instrument labeled "Text Validation"
-        And I enter "Test custom text" into the Notes Box field for the Data Collection Instrument labeled "Data Types"
-        And I click on the button labeled "Save" for the Data Collection Instrument labeled "Data Types"
-        Then I should see a table header and rows containing the following values in a table:
-            | Display the Lock option for this instrument? | Data Collection Instrument | Also display E-signature option on instrument? | Lock Record Custom Text   |
-            | [✓]                                          | Text Validation            | checkbox                                       | Test custom text          |
-            | [✓]                                          | Data Type                  | checkbox                                       | Test custom text          |
-            | [✓]                                          | Survey                     | checkbox                                       | Notes Box & "Save" button |
-            | checkbox                                     | Consent                    | checkbox                                       | Notes Box & "Save" button |
-
-
-        ##VERIFY_LOG
-        When I click on the link labeled "Logging"
-        Then I should see a table header and rows containing the following values in the logging table:
-            | Username   | Action        | List of Data Changes OR Fields Exported |
-            | test_admin | Manage/Design | Customize record locking                |
-            | test_admin | Manage/Design | Customize record locking                |
-
-        ##VERIFY: custom text in record
-        When I click on the link labeled "Record Status Dashboard"
-        And I locate the bubble for the "Text Validation" instrument on event "Event 1" for record ID "1" and click on the bubble
-        Then I should see "Text Validation"
-        And I should see "Test custom text"
-
-        When I click on the link labeled "Data Tapes"
-        Then I should see "Data Types"
-        And I should see "Test custom text"
-
-        #FUNCTIONAL REQUIREMENT
-        ##ACTION Edit / Remove Custom Text
-        When I click on the link labeled "Customize & Manage Locking/E-signatures"
-        And I click on the button labeled "I understand. Let me make changes" in the dialog box
-        And I click on the edit image for the Data Collection Instrument labeled "Text Validation"
-        And I enter "New custom text" into the Notes Box field for the Data Collection Instrument labeled "Text Validation"
-        And I click on the button labeled "Save" for the Data Collection Instrument labeled "Text Validation"
-        And I click on the remove image for the Data Collection Instrument labeled "Data Types"
-        And I click on the button labeled "OK" in the pop-up box
-        Then I should see a table header and rows containing the following values in a table:
-            | Display the Lock option for this instrument? | Data Collection Instrument | Also display E-signature option on instrument? | Lock Record Custom Text   |
-            | [✓]                                          | Text Validation            | [✓]                                            | New custom text           |
-            | [✓]                                          | Data Type                  | [✓]                                            | Notes Box & "Save" button |
-            | [✓]                                          | Survey                     | [✓]                                            | Notes Box & "Save" button |
-            | [✓]                                          | Consent                    | [✓]                                            | Notes Box & "Save" button |
-
-
-        ##VERIFY_LOG
-        When I click on the link labeled "Logging"
-        Then I should see a table header and rows containing the following values in the logging table:
-            | Username   | Action        | List of Data Changes OR Fields Exported |
-            | test_admin | Manage/Design | Customize record locking                |
-            | test_admin | Manage/Design | Customize record locking                |
-            | test_admin | Manage/Design | Customize record locking                |
-            | test_admin | Manage/Design | Customize record locking                |
-
-
-        ##VERIFY: custom text in record and revert back to template
-        When I click on the link labeled "Record Status Dashboard"
-        And I locate the bubble for the "Text Validation" instrument on event "Event 1" for record ID "1" and click on the bubble
-        Then I should see "Text Validation"
-        And I should see "New custom text"
-
-        When I click on the link labeled "Data Tapes"
-        Then I should see "Data Types"
-        And I should see "Lock this instrument?"
+  Scenario: ##VERIFY: form NOT display lock function
+    When I click on the link labeled "Record Status Dashboard"
+    And I locate the bubble for the "Data Type " instrument on event "Event 1" for record ID "1" and click on the bubble
+    Then I should see "Data Type "
+    And I should NOT "Lock this instrument?"
+    And I click on the button labeled "Save & Exit Form"
+    Then I should see "Record Home Page"
 #END

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0400. - Lock status display.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0400. - Lock status display.feature
@@ -48,6 +48,7 @@ Feature: User Interface: The tool shall display locked status of forms for all r
         And I locate the bubble for the "Text Validation" instrument on event "Event 1" for record ID "3" and click on the bubble
 
         Then I should see "Text Validation"
+        #FUNCTIONAL REQUIREMENT C.2.19.200.100 Display forms that are designated
         And I should see a checkbox labeled "Lock this instrument?" that is unchecked
         When I click on the checkbox for the field labeled "Lock this instrument?"
         And I click on the button labeled "Save & Exit Form"

--- a/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0600. - Locking module navigation.feature
+++ b/Feature Tests/C/Record Locking & E-Signatures_19/C.2.19.0600. - Locking module navigation.feature
@@ -16,27 +16,7 @@ Feature: User Interface: The tool shall support the ability to navigate directly
         And I click on the radio labeled "Keep ALL data saved so far" in the dialog box
         And I click on the button labeled "YES, Move to Production Status" in the dialog box to request a change in project status
         Then I should see Project status: "Production"
-
-        #USER_RIGHTS
-        When I click on the link labeled "User Rights"
-        And I enter "Test_User1" into the input field labeled "Add with custom rights"
-        And I click on the button labeled "Add with custom rights"
-        Then I should see 'Adding new user "Test_User1"'
-
-        When I click on the checkbox for the field labeled "Record Locking Customization"
-        And I select the radio option "Locking / Unlocking with E-signature authority" for the field labeled "Lock / Unlock Records (instrument level)"
-        And I click on the button labeled "Close" in the dialog box
-        And I click on the checkbox for the field labeled "Lock/Unlock *Entire* Records (record level)"
-        And I click on the button labeled "Add user"
-        Then I should see 'User "Test_User1" was successfully added'
-
-        ##VERIFY_LOG
-        When I click on the link labeled "Logging"
-        Then I should see a table header and rows containing the following values in the logging table:
-            | Username   | Action              | List of Data Changes OR Fields Exported |
-            | test_admin | Add user test_user1 | user = 'test_user1'                     |
-
-
+ 
         #FUNCTIONAL REQUIREMENT
         ##ACTION Navigate to record
         When I click on the link labeled "Customize & Manage Locking/E-signatures"


### PR DESCRIPTION
During manual testing, it was discovered that C.2.19.200 was actually C.2.19.100, and some steps were needed to clarify.  C.2.19.200  is a #PARENT and can be associated with #CHILD C.2.19.400.100.  With modifications to #CHILD C.2.19.400.100.,  #PARENT C.2.19.200  could be marked redundant in the future and tested elsewhere. 